### PR TITLE
add features to find LFT

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,14 @@ version = "0.1.0"
 [deps]
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 ControlSystems = "a6e380b2-a6ca-5380-bf3e-84a91bcd477e"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 ComponentArrays = "0.9"

--- a/src/RobustAndOptimalControl.jl
+++ b/src/RobustAndOptimalControl.jl
@@ -27,7 +27,7 @@ include("h2_design.jl")
 export named_ss
 include("named_systems.jl")
 
-export find_lft
+export find_lft, δ
 include("find_lft.jl")
 
 

--- a/src/RobustAndOptimalControl.jl
+++ b/src/RobustAndOptimalControl.jl
@@ -6,22 +6,29 @@ using ControlSystems
 import ControlSystems: ss, ssdata, ninputs, noutputs, nstates, isdiscrete, iscontinuous, to_matrix, timeevol, _string_mat_with_headers, PartionedStateSpace, common_timeevol
 
 using ComponentArrays
+
+using MonteCarloMeasurements, Optim, UnPack
+import Distributions: Uniform
+
 export ExtendedStateSpace
+include("ExtendedStateSpace.jl")
 
 export hinfsynthesize, hinfassumptions, hinfpartition, hinfsignals, bilinearc2d, bilineard2c, fudge_inv
+include("hinfinity_design.jl")
 
-export h2synthesize
+include("plotting.jl")
 
 export frequency_weighted_reduction, controller_reduction
+include("reduction.jl")
+
+export h2synthesize
+include("h2_design.jl")
 
 export named_ss
-
-include("ExtendedStateSpace.jl")
-include("hinfinity_design.jl")
-include("plotting.jl")
-include("reduction.jl")
-include("h2_design.jl")
 include("named_systems.jl")
+
+export find_lft
+include("find_lft.jl")
 
 
 end

--- a/src/find_lft.jl
+++ b/src/find_lft.jl
@@ -1,3 +1,10 @@
+"""
+    δ(N=32)
+
+Create an uncertain element of `N` uniformly distributed samples ∈ [-1, 1]
+"""
+δ(N=32) = StaticParticles(N, Uniform(-1, 1))
+
 function ControlSystems.lft(M11::AbstractMatrix, M12::AbstractMatrix, M21::AbstractMatrix, M22::AbstractMatrix, d::AbstractMatrix)
     M11 + M12 * d*((I - M22*d)\M21)
 end
@@ -40,7 +47,7 @@ function ControlSystems.ss(l::LFT, P0::AbstractStateSpace)
     ss(A, B, P0.C, P0.D)
 end
 
-find_lft(sys::StateSpace{<:Any, <:StaticParticles{<:Any, N}}, n_uncertain::Int)  where N = find_lft(sys, [StaticParticles(N, Uniform(-1,1)) for _ in 1:n_uncertain], wass)
+find_lft(sys::StateSpace{<:Any, <:StaticParticles{<:Any, N}}, n_uncertain::Int)  where N = find_lft(sys, [δ(N) for _ in 1:n_uncertain], wass)
 
 """
     l = find_lft(sys::StateSpace{<:Any, <:StaticParticles{<:Any, N}}, δ) where N

--- a/src/find_lft.jl
+++ b/src/find_lft.jl
@@ -1,0 +1,97 @@
+function ControlSystems.lft(M11::AbstractMatrix, M12::AbstractMatrix, M21::AbstractMatrix, M22::AbstractMatrix, d::AbstractMatrix)
+    M11 + M12 * d*((I - M22*d)\M21)
+end
+
+wass(a, b) = wasserstein(a,b,2)
+l2(a,b) = sum(abs2.(a.particles .- b.particles))
+
+wass(a::AbstractArray, b::AbstractArray) = sum(wass(a,b) for (a,b) in zip(a,b)) # shouldn't be allowed to permute all particles individually?
+l2(a::AbstractArray, b::AbstractArray) = sum(l2(a,b) for (a,b) in zip(a,b)) # shouldn't be allowed to permute all particles individually?
+
+
+function pars2lft(M11, p, δ)
+    @unpack M12, M21, M22 = p
+    Phat = lft(M11, M12, M21, M22, δ)
+end
+
+struct LFT
+    M11
+    M12
+    M21
+    M22
+    d
+end
+
+Base.Matrix(l::LFT) = [l.M11 l.M12; l.M21 l.M22]
+
+function Base.show(io::IO, l::LFT)
+    display(Matrix(l))
+end
+
+function ControlSystems.lft(l::LFT)
+    @unpack M11, M12, M21, M22, d = l
+    lft(M11, M12, M21, M22, d)
+end
+
+function ControlSystems.ss(l::LFT, P0::AbstractStateSpace)
+    P = lft(l)
+    A = P[:, 1:P0.nx]
+    B = P[:, P0.nx+1:end]
+    ss(A, B, P0.C, P0.D)
+end
+
+find_lft(sys::StateSpace{<:Any, <:StaticParticles{<:Any, N}}, n_uncertain::Int)  where N = find_lft(sys, [StaticParticles(N, Uniform(-1,1)) for _ in 1:n_uncertain], wass)
+
+"""
+    l = find_lft(sys::StateSpace{<:Any, <:StaticParticles{<:Any, N}}, δ) where N
+
+Given an systems `sys` with uncertain coefficients in the form of `StaticParticles`, find a lower linear fractional transformation `M` such that `lft(M, δ) ≈ sys`. 
+
+`δ` can be either the source of uncertainty in `sys`, i.e., a vector of the unique uncertain parameters that were used to create `sys`. These should be constructed as uniform randomly distributed particles for most robust-control theory to be applicable. 
+`δ` can also be an integer, in which case a numer of `δ` sources of uncertainty are automatically created. This could be used for order reduction if the number of uncertainty sources in `sys` is large.
+
+Note, uncertainty in `sys` is only supported in `A` and `B`, `C` and `D` must be deterministic.
+
+Returns `l::LFT` that internaly contains all four blocks of `M` as well as `δ`. Call `ss(l,sys)` do obtain `lft(M, δ) ≈ sys`.
+
+Call `Matrix(l)` to obtain `M = [M11 M12; M21 M22]`
+"""
+function find_lft(sys::StateSpace{<:Any, <:StaticParticles{<:Any, N}}, delta, dist::F = l2) where {N, F}
+    n_uncertain = length(delta)
+    P = [sys.A sys.B]
+    M11 = mean.(P)
+    δ = Diagonal(delta)
+    function loss(p)
+        Phat = pars2lft(M11, p, δ)
+        dist(P, Phat) #+ 1e-7*sum(abs, p)
+    end
+    p0 = ComponentVector(
+        M12 = 0.00001randn(sys.nx, n_uncertain),
+        M21 = 0.00001randn(n_uncertain, sys.nx+sys.nu),
+        M22 = 0.00001randn(n_uncertain, n_uncertain),
+    )
+    res = Optim.optimize(
+        loss,
+        p0,
+        LBFGS(),
+        Optim.Options(
+            store_trace       = true,
+            show_trace        = true,
+            show_every        = 5,
+            iterations        = 40000,
+            allow_f_increases = false,
+            time_limit        = 45,
+            x_tol             = 1e-8,
+            f_reltol          = 0,
+            g_tol             = 1e-8,
+            f_calls_limit     = 0,
+            g_calls_limit     = 0,
+        ),
+        # autodiff = :forward
+    )
+    p = res.minimizer
+    LFT(M11, p.M12, p.M21, p.M22, δ), res
+
+end
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,4 +17,9 @@ using Test
         @info "Testing Named systems"
         include("test_named_systems.jl")
     end
+
+    @testset "find_lft" begin
+        @info "Testing find_lft"
+        include("test_find_lft.jl")
+    end
 end

--- a/test/test_find_lft.jl
+++ b/test/test_find_lft.jl
@@ -1,12 +1,14 @@
+using RobustAndOptimalControl, Random, Statistics, MonteCarloMeasurements, ControlSystems
+Random.seed!(0)
 unsafe_comparisons()
-u1 = 2*StaticParticles(32, Uniform(-1,1))
-u2 = 5*StaticParticles(32, Uniform(-1,1))
-u3 = 0.2*StaticParticles(32, Uniform(-1,1))
+u1 = 2*δ()
+u2 = 5*δ()
+u3 = 0.2*δ()
 nx, nu, ny = 10, 5, 5
-A = randn(nx,nx) .+ 0 .* StaticParticles.(32)
+A = randn(nx,nx) .+ 0 .* δ.()
 A[1,1] = 4 + u1
 A[2, 3] = 9 + u2
-B = randn(nx, nu) .+ 0 .* StaticParticles.(32)
+B = randn(nx, nu) .+ 0 .* δ.()
 B[4, 1] = 2 + u3
 
 sys = ss(A, B, randn(ny,nx), 0)
@@ -14,11 +16,11 @@ l, res = find_lft(sys, [u1, u2, u3])
 
 sysh = ss(l,sys)
 
-@test mean.(sysh.A) ≈ mean.(sys.A) atol=1e-6
-@test std.(sysh.A) ≈ std.(sys.A) atol=1e-6
-@test mean.(sysh.B) ≈ mean.(sys.B) atol=1e-6
-@test std.(sysh.B) ≈ std.(sys.B) atol=1e-6
-@test mean.(sysh.C) ≈ mean.(sys.C) atol=1e-6
-@test std.(sysh.C) ≈ std.(sys.C) atol=1e-6
-@test mean.(sysh.D) ≈ mean.(sys.D) atol=1e-6
-@test std.(sysh.D) ≈ std.(sys.D) atol=1e-6
+@test mean.(sysh.A) ≈ mean.(sys.A) atol=1e-5
+@test std.(sysh.A) ≈ std.(sys.A) atol=1e-5
+@test mean.(sysh.B) ≈ mean.(sys.B) atol=1e-5
+@test std.(sysh.B) ≈ std.(sys.B) atol=1e-5
+@test mean.(sysh.C) ≈ mean.(sys.C) atol=1e-5
+@test std.(sysh.C) ≈ std.(sys.C) atol=1e-5
+@test mean.(sysh.D) ≈ mean.(sys.D) atol=1e-5
+@test std.(sysh.D) ≈ std.(sys.D) atol=1e-5

--- a/test/test_find_lft.jl
+++ b/test/test_find_lft.jl
@@ -1,0 +1,24 @@
+unsafe_comparisons()
+u1 = 2*StaticParticles(32, Uniform(-1,1))
+u2 = 5*StaticParticles(32, Uniform(-1,1))
+u3 = 0.2*StaticParticles(32, Uniform(-1,1))
+nx, nu, ny = 10, 5, 5
+A = randn(nx,nx) .+ 0 .* StaticParticles.(32)
+A[1,1] = 4 + u1
+A[2, 3] = 9 + u2
+B = randn(nx, nu) .+ 0 .* StaticParticles.(32)
+B[4, 1] = 2 + u3
+
+sys = ss(A, B, randn(ny,nx), 0)
+l, res = find_lft(sys, [u1, u2, u3])
+
+sysh = ss(l,sys)
+
+@test mean.(sysh.A) ≈ mean.(sys.A) atol=1e-6
+@test std.(sysh.A) ≈ std.(sys.A) atol=1e-6
+@test mean.(sysh.B) ≈ mean.(sys.B) atol=1e-6
+@test std.(sysh.B) ≈ std.(sys.B) atol=1e-6
+@test mean.(sysh.C) ≈ mean.(sys.C) atol=1e-6
+@test std.(sysh.C) ≈ std.(sys.C) atol=1e-6
+@test mean.(sysh.D) ≈ mean.(sys.D) atol=1e-6
+@test std.(sysh.D) ≈ std.(sys.D) atol=1e-6


### PR DESCRIPTION
Given an systems `sys` with uncertain coefficients in the form of `StaticParticles`, find a lower linear fractional transformation `M` such that `lft(M, δ) ≈ sys`. 
`δ` can be either the source of uncertainty in `sys`, i.e., a vector of the unique uncertain parameters that were used to create `sys`. These should be constructed as uniform randomly distributed particles for most robust-control theory to be applicable. 
`δ` can also be an integer, in which case a numer of `δ` sources of uncertainty are automatically created. This could be used for order reduction if the number of uncertainty sources in `sys` is large.
Note, uncertainty in `sys` is only supported in `A` and `B`, `C` and `D` must be deterministic.
Returns `l::LFT` that internaly contains all four blocks of `M` as well as `δ`. Call `ss(l,sys)` do obtain `lft(M, δ) ≈ sys`.
Call `Matrix(l)` to obtain `M = [M11 M12; M21 M22]`