### PR TITLE
avoid calling `sminreal` automatically

### DIFF
--- a/examples/complicated_feedback.jl
+++ b/examples/complicated_feedback.jl
@@ -45,8 +45,8 @@ w1 = [:uF]
 G = ROC.connect([F, R, C, P, addP, addC], connections; w1)
 
 
-@test G[:yF, :uF].sys ≈ F.sys
-@test tf(G[:yR, :uF].sys) ≈ tf((R*F).sys)
+@test sminreal(G[:yF, :uF].sys) ≈ F.sys
+@test tf(sminreal(G[:yR, :uF].sys)) ≈ tf((R*F).sys)
 
 
 # uF -> uP
@@ -59,7 +59,7 @@ isinteractive() && bodeplot([automatic, manual], w)
 # uF -> yC
 manual = feedback(C.sys, P.sys)*R.sys*F.sys - feedback(P.sys * C.sys)*F.sys
 # manual = C*inv(1+P.sys*C.sys)*R.sys*F.sys
-automatic = G[:yC, :uF]
+automatic = sminreal(G[:yC, :uF])
 @test linfnorm(manual-automatic)[1] < 1e-6
 isinteractive() && bodeplot([automatic, manual], w)
 @test automatic.nx == 9

--- a/src/named_systems2.jl
+++ b/src/named_systems2.jl
@@ -185,7 +185,7 @@ function Base.getindex(sys::NamedStateSpace{T,S}, i::NamedIndex, j::NamedIndex) 
         sys.x,
         sys.u[jj],
         sys.y[ii],
-    ) |> sminreal
+    ) # |> sminreal
 end
 
 function Base.getindex(sys::NamedStateSpace{T,S}, inds...) where {T,S}
@@ -198,7 +198,7 @@ function Base.getindex(sys::NamedStateSpace{T,S}, inds...) where {T,S}
         sys.x,
         sys.u[cols],
         sys.y[rows],
-    ) |> sminreal
+    ) # |> sminreal
 end
 
 function Base.show(io::IO, G::NamedStateSpace)


### PR DESCRIPTION
since this may remove states that are to be used for a disturbance observer etc.