### PR TITLE
fix bug in prefix matching

### DIFF
--- a/src/named_systems2.jl
+++ b/src/named_systems2.jl
@@ -539,14 +539,20 @@ names2indices(::Colon, allnames) = 1:length(allnames)
 function names2indices(names, allnames)
     inds = Union{Nothing, Int}[findfirst(==(n), allnames) for n in names]
     snames = string.(allnames)
-    for i in eachindex(inds)
+    i = 1
+    k = 1
+    while i <= length(inds)
         if inds[i] === nothing
             # try finding symbols with given prefix
-            newi = findall(startswith(string(names[i])), snames)
+            newi = findall(startswith(string(names[k])), snames)
             newi === nothing || isempty(newi) && error("The indexed NamedSystem has no signal named $(names[i]), available names are $(allnames)")
             deleteat!(inds, i)
             foreach(j->insert!(inds, j+i-1, newi[j]), 1:length(newi))
+            i += length(newi)
+        else
+            i += 1
         end
+        k += 1
     end
     inds
 end

--- a/test/test_named_systems2.jl
+++ b/test/test_named_systems2.jl
@@ -274,3 +274,8 @@ sp = splitter(:u2, 2)
     @info "Testing complicated_feedback"
     include("../examples/complicated_feedback.jl")
 end
+
+## Test bug with prefix matching, where one of the provided indices matches more than one variable (:y), but there are still remaining indices to find (:za)
+G1 = ssrand(4,2,2)
+s1 = named_ss(G1, u = :u, y=[:y1, :y2, :w, :za]) 
+@test s1[[:y, :z], :] == s1[[1,2,4], :]


### PR DESCRIPTION
Test bug with prefix matching, where one of the provided indices matches more than one variable, but there are still remaining indices to find