### PR TITLE
docs: remove deploydocs deps

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -28,6 +28,5 @@ makedocs(
 )
 
 deploydocs(
-      deps = Deps.pip("pygments", "mkdocs", "python-markdown-math", "mkdocs-cinder"),
       repo = "github.com/JuliaControl/RobustAndOptimalControl.jl.git",
 )


### PR DESCRIPTION
MkDocs is not being used to build documentation (anymore?), so those dependencies are unnecessary I think?