### PR TITLE
Minor typo correction in a message returned by hinfassumption.

### DIFF
--- a/src/hinfinity_design.jl
+++ b/src/hinfinity_design.jl
@@ -71,7 +71,7 @@ function hinfassumptions(P::ExtendedStateSpace; verbose = true)
     end
 
     # All assumptions have passed, and we may proceed with the synthesis
-    verbose && println("All assumtions are satisfied!")
+    verbose && println("All assumptions are satisfied!")
     return true
 end
 


### PR DESCRIPTION
Just a single minor typo correction in a message returned by hinfassumption function.