### PR TITLE
Fix MIMO Ai-disturbance, resonant disturbance shape and docs

### DIFF
--- a/src/model_augmentation.jl
+++ b/src/model_augmentation.jl
@@ -45,15 +45,20 @@ end
 """
     add_low_frequency_disturbance(sys::StateSpace, Ai::Integer; ϵ = 0)
 
-A disturbance affecting only state `Ai`.
+Augment `sys` with a single low-frequency (integrating if `ϵ=0`) disturbance state
+affecting state index `Ai` of `sys`.
+
+# Arguments:
+- `Ai`: Index of the plant state the disturbance is added to. Must satisfy `1 ≤ Ai ≤ sys.nx`.
+- `ϵ`: Move the integrator pole `ϵ` into the stable region (continuous: pole at `-ϵ`; discrete: pole at `1-ϵ`).
 """
 function add_low_frequency_disturbance(sys::AbstractStateSpace, Ai::Integer; ϵ=0)
     nx,nu,ny = sys.nx,sys.nu,sys.ny
     1 ≤ Ai ≤ nx || throw(ArgumentError("Ai must be a valid state index"))
     Cd = zeros(nx, 1)
     Cd[Ai] = 1
-    Ad = -ϵ*I(nu)
-    isdiscrete(sys) && (Ad += I)
+    Ad = fill(-float(ϵ), 1, 1)
+    isdiscrete(sys) && (Ad .+= 1)
     add_disturbance(sys, Ad, Cd)
 end
 
@@ -88,26 +93,31 @@ end
 """
     add_resonant_disturbance(sys::StateSpace{Continuous}, ω, ζ, Ai::Int; measurement = false)
 
-Augment `sys` with a resonant disturbance model.
+Augment `sys` with a resonant disturbance model. The added disturbance dynamics have
+eigenvalues `-ζ ± iω`, i.e. `ζ` is the decay rate and `ω` is the damped (oscillation)
+frequency. The characteristic polynomial of the continuous-time disturbance dynamics is
+`s² + 2ζs + (ζ² + ω²)`. For an undamped oscillator at frequency `ω`, choose `ζ = 0`.
 
 # Arguments:
-- `ω`: Frequency
-- `ζ`: Relative damping.
+- `ω`: Damped (oscillation) frequency, i.e. the imaginary part of the disturbance poles.
+- `ζ`: Decay rate, i.e. the real part of the disturbance poles (units: inverse time).
 - `Ai`: The affected state
-- `measurement`: If true, the disturbace is acting on the output, this will cause the controller to have zeros at ω (roots of poly s² + 2ζωs + ω²). If false, the disturbance is acting on the input, this will cause the controller to have poles at ω (roots of poly s² + 2ζωs + ω²).
+- `measurement`: If true, the disturbance acts on the output, causing the controller to have zeros near the disturbance poles. If false, the disturbance acts on the input, causing the controller to have poles near the disturbance poles.
 """
 function add_resonant_disturbance(sys::AbstractStateSpace, ω, ζ, Ai::Integer; measurement=false)
+    A, _, _, _ = ControlSystemsBase.ssdata(sys)
+    T = eltype(A)
     nx,nu,ny = sys.nx,sys.nu,sys.ny
     if measurement
         1 ≤ Ai ≤ sys.ny || throw(ArgumentError("Ai must be a valid output index"))
-        Cd = zeros(ny, 2)
+        Cd = zeros(T, ny, 2)
         Cd[Ai, 1] = 1
     else
         1 ≤ Ai ≤ sys.nx || throw(ArgumentError("Ai must be a valid state index"))
-        Cd = zeros(nx, 2)
+        Cd = zeros(T, nx, 2)
         Cd[Ai, 1] = 1
     end
-    Ad = [-ζ -ω; ω -ζ]
+    Ad = T[-ζ -ω; ω -ζ]
     if isdiscrete(sys)
         Ad = exp(Ad * sys.Ts)
     end
@@ -115,20 +125,37 @@ function add_resonant_disturbance(sys::AbstractStateSpace, ω, ζ, Ai::Integer; 
 end
 
 """
-    add_resonant_disturbance(sys::AbstractStateSpace, ω, ζ, Bd::AbstractArray)
+    add_resonant_disturbance(sys::AbstractStateSpace, ω, ζ, Bd::AbstractArray; measurement = false)
 
-- `Bd`: The disturbance input matrix.
+Augment `sys` with a resonant disturbance whose injection into `sys` is described by `Bd`.
+See the integer-`Ai` method for the meaning of `ω` and `ζ`.
+
+# Arguments:
+- `Bd`: Disturbance injection matrix.
+    - If `measurement = false`, `Bd` indicates how the disturbance states affect the plant
+      states. It must have `sys.nx` rows and either `1` or `2` columns. With one column,
+      only the first (cosine-like) resonant state injects into the plant; with two columns,
+      both resonant states inject.
+    - If `measurement = true`, `Bd` indicates how the disturbance states affect the plant
+      outputs and must have `sys.ny` rows and `2` columns.
 """
 function add_resonant_disturbance(sys::AbstractStateSpace, ω, ζ, Bd::AbstractArray; measurement=false)
-    Ad = [-ζ -float(ω); ω -ζ]
+    A, _, _, _ = ControlSystemsBase.ssdata(sys)
+    T = eltype(A)
+    Ad = T[-ζ -ω; ω -ζ]
     if isdiscrete(sys)
-        Ad .*= sys.Ts
-        Ad = exp(Ad)
+        Ad = exp(Ad * sys.Ts)
     end
     if measurement
+        size(Bd, 1) == sys.ny || throw(ArgumentError("Bd must have sys.ny=$(sys.ny) rows in the measurement case, got $(size(Bd, 1))"))
+        size(Bd, 2) == 2 || throw(ArgumentError("Bd must have 2 columns in the measurement case (one per resonant state), got $(size(Bd, 2))"))
         add_measurement_disturbance(sys, Ad, Bd)
     else
-        add_disturbance(sys, Ad, [Bd zeros(sys.nx)])
+        size(Bd, 1) == sys.nx || throw(ArgumentError("Bd must have sys.nx=$(sys.nx) rows, got $(size(Bd, 1))"))
+        nc = size(Bd, 2)
+        nc == 1 || nc == 2 || throw(ArgumentError("Bd must have 1 or 2 columns, got $nc"))
+        Cd = nc == 2 ? Bd : [Bd zeros(T, sys.nx)]
+        add_disturbance(sys, Ad, Cd)
     end
 end
 
@@ -210,16 +237,16 @@ function add_input_integrator(sys::AbstractStateSpace, ui=1; ϵ=0)
     T = eltype(A)
     nx,nu,ny = sys.nx,sys.nu,sys.ny
     1 ≤ ui ≤ nu || throw(ArgumentError("ui must be a valid input index"))
-    Cd = zeros(T, 1, nx+1)
-    Cd[end] = 1
-    Bd = zeros(T, 1, nu)
-    Bd[ui] = ControlSystemsBase.isdiscrete(sys) ? sys.Ts : 1
-    Ad = -ϵ*I(1)
-    isdiscrete(sys) && (Ad += I)
+    C_int_row = zeros(T, 1, nx+1)
+    C_int_row[end] = 1
+    B_int_row = zeros(T, 1, nu)
+    B_int_row[ui] = ControlSystemsBase.isdiscrete(sys) ? sys.Ts : 1
+    A_int = -ϵ*I(1)
+    isdiscrete(sys) && (A_int += I)
 
-    Ae = [A zeros(T, nx, 1); zeros(T, size(Ad, 1), nx) Ad]
-    Be = [B; Bd]
-    Ce = [[C zeros(T, ny, 1)]; Cd]
+    Ae = [A zeros(T, nx, 1); zeros(T, size(A_int, 1), nx) A_int]
+    Be = [B; B_int_row]
+    Ce = [[C zeros(T, ny, 1)]; C_int_row]
     De = [D; zeros(T, 1, nu)]
     ss(Ae,Be,Ce,De,sys.timeevol)
 

--- a/test/test_augmentation.jl
+++ b/test/test_augmentation.jl
@@ -9,7 +9,7 @@ Gd = add_low_frequency_disturbance(G)
 @test any(isapprox(0, atol=eps()), poles(Gd))
 
 Gd = add_low_frequency_disturbance(G, measurement=true)
-Gd.C[end] == 1
+@test Gd.C[end] == 1
 @test Gd.nx == 4
 @test rank(obsv(Gd)) == 4
 @test rank(ctrb(Gd)) == 3
@@ -22,6 +22,19 @@ Gd = add_low_frequency_disturbance(G)
 @test rank(ctrb(Gd)) == G.nx
 @test any(isapprox(0, atol=eps()), poles(Gd))
 @test Gd.A[end-1:end, end-1:end] == 0I
+
+# Integer-Ai variant on a MIMO plant (nu > 1) — regression for sizing of Ad
+G = ssrand(2, 3, 4, proper=true)
+Gd = add_low_frequency_disturbance(G, 2)
+@test Gd.nx == G.nx + 1
+@test rank(obsv(Gd)) == Gd.nx
+@test any(isapprox(0, atol=eps()), poles(Gd))
+@test Gd.A[1:G.nx, end] == [0, 1, 0, 0]
+@test Gd.A[end, end] == 0
+
+# Same, discrete time
+Gddisc = add_low_frequency_disturbance(c2d(G, 0.1), 2)
+@test Gddisc.A[end, end] == 1
 
 G = ssrand(2,4,3, proper=true)
 Gd = add_low_frequency_disturbance(G, measurement=true)
@@ -88,6 +101,17 @@ Gd = add_resonant_disturbance(G, 1, 0, [1.0 0.0], measurement=true)
 allapproxin(a, b) = all(any(a .≈ b', dims=2))
 @test allapproxin(poles(Gd), [eigvals(exp([0 -1; 1 0]*0.1)); exp(-1*0.1)])
 @test size(Gd.C, 2) == 3  # C matrix extended with disturbance states
+
+# Two-column Bd (both resonant states inject into the plant state)
+G = c2d(ss(tf(1.0, [1, 1])), 0.1)
+Gd = add_resonant_disturbance(G, 1, 0, [1.0 0.5])
+@test Gd.nx == 3
+@test allapproxin(poles(Gd), [eigvals(exp([0 -1; 1 0]*0.1)); exp(-1*0.1)])
+
+# Input validation for Bd shape
+@test_throws ArgumentError add_resonant_disturbance(G, 1, 0, zeros(G.nx, 3))
+@test_throws ArgumentError add_resonant_disturbance(G, 1, 0, zeros(G.nx + 1, 1))
+@test_throws ArgumentError add_resonant_disturbance(G, 1, 0, zeros(G.ny, 1), measurement=true)
 
 
 ##


### PR DESCRIPTION
## Summary

Review-driven cleanup of `src/model_augmentation.jl`.

- **`add_low_frequency_disturbance(sys, Ai::Integer)`**: `Ad` is now `1×1`. The previous `Ad = -ϵ*I(nu)` only worked for SISO plants; for `nu > 1` the augmented `A = [A Cd; 0 Ad]` had mismatched column counts.
- **`add_resonant_disturbance(sys, ω, ζ, Bd)`**: validate `Bd` shape with informative errors and accept a 2-column `Bd` so both resonant states can inject into the plant. The non-measurement branch previously assumed `Bd` had exactly one column and silently constructed an ill-shaped `Cd` otherwise.
- **`add_resonant_disturbance` docs**: corrected the polynomial / parameter meaning. The implemented `Ad = [-ζ -ω; ω -ζ]` has eigenvalues `-ζ ± iω` and characteristic polynomial `s² + 2ζs + (ζ² + ω²)`, not the previously documented `s² + 2ζωs + ω²`. `ζ` is now described as the decay rate and `ω` as the damped frequency.
- **Element types**: `Ad`/`Cd` in `add_resonant_disturbance` now use `eltype(sys.A)` for consistency with the other augmentation routines.
- **`add_input_integrator`**: renamed local `Ad`/`Bd`/`Cd` to `A_int`/`B_int_row`/`C_int_row` to disambiguate from the disturbance-augmentation naming used elsewhere in the file.

## Test plan

- [x] `julia --project -e 'using LinearAlgebra, RobustAndOptimalControl, Test; include("test/test_augmentation.jl")'` — passes, including the new MIMO `Ai`-integer regression, the new two-column `Bd` test, and the new `Bd`-shape validation tests.
- [x] `julia --project -e 'using Plots, LinearAlgebra, RobustAndOptimalControl, Test; include("test/test_lqg.jl")'` — passes (`add_input_differentiator` / `add_output_integrator` callers).
- [ ] Full `Pkg.test()` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)