### PR TITLE
Fix UndefVarError in merge_nonunique_inputs warning

### DIFF
--- a/src/named_systems2.jl
+++ b/src/named_systems2.jl
@@ -610,8 +610,8 @@ function merge_nonunique_inputs(sys)
         # Check that the B-matrix entries are non-overlapping
         Bi = sys.B[:, inds]
         Di = sys.D[:, inds]
-        any(>(1), sum(.! iszero.(Bi), dims=2)) && @warn("Input names are not unique and the multiple B-matrix columns associated with the name $(u[i]) have a non-empty intersection of non-zero entries.")
-        any(>(1), sum(.! iszero.(Di), dims=2)) && @warn("Input names are not unique and the multiple D-matrix columns associated with the name $(u[i]) have a non-empty intersection of non-zero entries.")
+        any(>(1), sum(.! iszero.(Bi), dims=2)) && @warn("Input names are not unique and the multiple B-matrix columns associated with the name $(inputnames[i]) have a non-empty intersection of non-zero entries.")
+        any(>(1), sum(.! iszero.(Di), dims=2)) && @warn("Input names are not unique and the multiple D-matrix columns associated with the name $(inputnames[i]) have a non-empty intersection of non-zero entries.")
         B = copy(sys.B)
         D = copy(sys.D)
         B[:, inds[1]] = sum(Bi, dims=2)

--- a/test/test_named_systems2.jl
+++ b/test/test_named_systems2.jl
@@ -544,3 +544,18 @@ isys = 2/s1
 P = named_ss(ssrand(1,1,2, Ts=1.0))
 C = named_ss(ssrand(1,1,2, Ts=1.0))
 @test gangoffour(P, C) isa NTuple{4, NamedStateSpace{Discrete{Float64}, StateSpace{Discrete{Float64}, Float64}}}
+
+## merge_nonunique_inputs: warning path must not crash on overlapping B/D columns
+# Regression: previous code interpolated an undefined variable `u` and raised
+# UndefVarError instead of issuing the documented warning.
+let
+    A = -I(2)
+    B = [1.0  1.0; 0.0  1.0]   # both columns nonzero in row 1 -> overlap
+    C = [1.0 0.0]
+    D = [0.0 0.0]
+    nsys = named_ss(ss(A, B, C, D); u=[:u_dup, :u_dup], y=:y, unique=false)
+    merged = @test_logs (:warn, r"B-matrix columns") RobustAndOptimalControl.merge_nonunique_inputs(nsys)
+    @test merged.nu == 1
+    @test merged.u == [:u_dup]
+    @test merged.B == sum(B, dims=2)
+end


### PR DESCRIPTION
## Summary
- The `@warn` calls in `merge_nonunique_inputs` interpolated `$(u[i])`, but `u` is not defined inside that function. When the warning condition fires (overlapping non-zero entries between B/D columns being merged under the same input name) the result was an `UndefVarError`, not the documented warning.
- Use the local `inputnames[i]` instead, and add a regression test in `test_named_systems2.jl`.

## Test plan
- [x] New regression test constructs a system with overlapping B columns under a duplicated input name and asserts the warning is emitted (and that merging proceeds without error).
- [x] Existing `test_named_systems2.jl` tests still pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)