### PR TITLE
Fix typo lalbe -> label in nyquistcircles recipe

### DIFF
--- a/src/weights.jl
+++ b/src/weights.jl
@@ -168,7 +168,7 @@ nyquistcircles
     t = LinRange(0, 2pi, 100)
     re, im = cos.(t), sin.(t)
     @series begin
-        lalbe --> "Center"
+        label --> "Center"
         centers
     end
     for i in eachindex(radii)


### PR DESCRIPTION
## Summary
- The centers series in the `nyquistcircles` plot recipe used `lalbe` as the attribute name, which is not a Plots attribute.
- The documented "Center" label was silently dropped (and some Plots versions warn about the unknown attribute).

## Test plan
- [x] Manual smoke check via `nyquistcircles(w, centers, radii)`; "Center" entry now appears in the legend.
- [x] No source-level test coverage exists for plotting recipes; nothing automated to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)