### PR TITLE
Fix typo "shpuld" -> "should" in observer_controller D22 error

### DIFF
--- a/src/lqg.jl
+++ b/src/lqg.jl
@@ -373,7 +373,7 @@ function ControlSystemsBase.observer_controller(l::LQGProblem, L::AbstractMatrix
         Cc = L
         Dc = 0
         iszero(l.D11) || error("Nonzero D11 not supported")
-        iszero(l.D22) || error("Nonzero D22 not supported. The _transformP2Pbar is not used for LQG, but perhaps shpuld be?")
+        iszero(l.D22) || error("Nonzero D22 not supported. The _transformP2Pbar is not used for LQG, but perhaps should be?")
     end
     # do we need some way to specify which non-controllable inputs are measurable? No, because they will automatically appear in the measured outputs :)
     Gc = ss(Ac, Bc, Cc, Dc, l.timeevol)


### PR DESCRIPTION
## Summary
- Pure typo fix in the error message that fires when `observer_controller` is called on an `LQGProblem` with non-zero `D22` in the non-direct branch.

## Test plan
- [x] No behavior change beyond the message text; no test changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)