### PR TITLE
diskmargin: drop the delay-margin line from show

### DIFF
--- a/src/diskmargin.jl
+++ b/src/diskmargin.jl
@@ -64,14 +64,6 @@ function Base.show(io::IO, dm::Diskmargin)
         println(io, "Gain margins: [$(dm.γmin), $(dm.γmax)]")
     end
     println(io, "Phase margin: ", dm.ϕm)
-    delaymarg = π/180 * dm.ϕm / dm.ω0
-    print(io, "Delay margin: ", delaymarg, " s")
-    if isdiscrete(dm.L)
-        samples = delaymarg / dm.L.Ts
-        println(io, ",  ", isfinite(samples) ? floor(Int, samples) : samples, " samples")
-    else
-        println(io)
-    end
     println(io, "Skew: ", dm.σ)
     println(io, "Worst-case perturbation: ", dm.f0)
 end


### PR DESCRIPTION
## Motivation

`show(::Diskmargin)` printed a delay margin computed as `ϕm/ω0`, where `ω0` is the disk-margin critical frequency (the skewed-sensitivity peak).

This is misleading:
- It is not the classical delay margin, which uses the gain crossover frequency `ω_gc`. For a disk margin there is no clean gain crossover, and `ω0 ≠ ω_gc` in general.
- More importantly it is **not a valid lower bound** on the smallest destabilizing delay. A delay's phase lag `ωτ` grows linearly with frequency, so the binding frequency is wherever `ϕm(ω)/ω` is smallest — generally not `ω0`. Evaluating the ratio only at `ω0` can overstate the tolerable delay.

A genuine lower bound would be `min_ω ϕm(ω)/ω`, which requires the frequency-dependent disk margin rather than the single critical-frequency value. Rather than print a number that reads as a guarantee but isn't one, this PR drops the line. A proper `delaymargin` based on the frequency sweep can be added later if wanted.

## Change

Remove the "Delay margin" (and discrete "samples") output from `Base.show(::Diskmargin)`. No tests or docs depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)