### PR TITLE
Widen LinearMPC compat to 0.8, 0.9 and 0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RobustAndOptimalControl"
 uuid = "21fd56a4-db03-40ee-82ee-a87907bee541"
 authors = ["Fredrik Bagge Carlson", "Marcus Greiff"]
-version = "0.4.51"
+version = "0.4.52"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -36,7 +36,7 @@ ControlSystemsBase = "1.17"
 DescriptorSystems = "1.2"
 Distributions = "0.25"
 GenericSchur = "0.5.2"
-LinearMPC = "0.7"
+LinearMPC = "0.7, 0.8, 0.9, 0.10"
 MatrixEquations = "2"
 MatrixPencils = "1"
 MonteCarloMeasurements = "1.0"


### PR DESCRIPTION
`LinearMPC = "0.7"` in `[compat]` (registered as `WeakCompat` for `["0.4.47 - 0"]`, i.e. every version that has the extension) pins any environment loading `RobustAndOptimalControlLinearMPCExt` to LinearMPC 0.7.x. That has a consequence well outside this package:

* LinearMPC 0.7.x requires `DAQPBase = "0.3"` (0.8 → `0.3.5 - 0.3`, 0.9 → `0.4.4 - 0.4`, 0.10 → `0.5`).
* So DAQPBase 0.5 — and therefore DAQP 0.9 — is unreachable in any environment that also has RobustAndOptimalControl ≥ 0.4.47.
* Since 0.4.46 caps `Optim = "1.5.0 - 1"`, a downstream package that wants DAQP 0.9 has to roll RobustAndOptimalControl back to 0.4.46, taking Optim down to 1.x and ControlSystemIdentification to 2.11.x with it.

That is exactly what JuliaComputing/DyadControlSystems.jl hit: DAQP 0.9 is unmergeable there today, and this compat bound is the reason.

### No code change needed

The extension only touches three LinearMPC entry points — `LinearMPC.MPC(F, G; Ts, C, Np, Nc, kwargs...)`, `LinearMPC.set_objective!` and `LinearMPC.set_bounds!` — and all three are unchanged across 0.7–0.10. `LinearMPC.Simulation` (used by the tests and the docstring example) is unchanged too.

### Testing

`test/test_linearmpc_ext.jl` run against each version in the widened range:

| LinearMPC | result |
|---|---|
| 0.7.3 (baseline) | 15/15 pass |
| 0.8.0 | 15/15 pass |
| 0.8.3 | 15/15 pass |
| 0.9.0 | 15/15 pass |
| 0.10.0 | 15/15 pass |

Julia 1.12.6. Patch version bumped to 0.4.52 so the widened bound can be registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)