### PR TITLE
Fix CI: correct H∞ bound in the reduction tests and de-flake the scaling-invariance tests

### DIFF
--- a/test/test_reduction.jl
+++ b/test/test_reduction.jl
@@ -62,7 +62,7 @@ sysr, _ = frequency_weighted_reduction(sys, sysi, 1, 3, residual=true)
 sysr2 = baltrunc(sys, n=3, residual=true)[1]
 @test sysr.nx == 3
 @test norm(sys-sysr, Inf) < 3
-@test norm(sysi*(sys-sysr), Inf) < 0.4
+@test norm(sysi*(sys-sysr), Inf) < 0.5
 @test hinorm(minreal(sysi*(sys-sysr))) <= hinorm(minreal(sysi*(sys-sysr2))) 
 @test dcgain(sys)[] ≈ dcgain(sysr)[] rtol=1e-5 # test the residual property
 
@@ -315,22 +315,31 @@ sys_siso = ssrand(1,1,9,proper=true)
 scaleY = 5.0
 scaleU = 0.2
 
+# The scaled and unscaled reductions are compared on a frequency grid rather than through
+# hinfnorm2(minreal(sys1-sys2)): minreal occasionally leaves a near-cancelled pole close to
+# the imaginary axis, and the H∞ norm of the difference then comes out as Inf
+w_scale = exp10.(LinRange(-3, 3, 500))
+function relative_freqresp_diff(sys1, sys2)
+    F1 = freqresp(sys1, w_scale)
+    maximum(abs, F1 - freqresp(sys2, w_scale)) / maximum(abs, F1)
+end
+
 # baltrunc2: compare frequency response with and without scaling
 sysr_noscale, _ = baltrunc2(sys_siso; n=3)
 sysr_scale, _ = baltrunc2(sys_siso; n=3, scaleY=scaleY, scaleU=scaleU)
 @test sysr_noscale.nx == sysr_scale.nx == 3
-@test hinfnorm2(minreal(sysr_noscale - sysr_scale))[1] < 1e-5
+@test relative_freqresp_diff(sysr_noscale, sysr_scale) < 1e-8
 
 
 # baltrunc_coprime: compare frequency response with and without scaling
 sysr_coprime_noscale, _, _ = baltrunc_coprime(sys_siso; n=3)
 sysr_coprime_scale, _, _ = baltrunc_coprime(sys_siso; n=3, scaleY=scaleY, scaleU=scaleU)
 @test sysr_coprime_noscale.nx == sysr_coprime_scale.nx == 3
-@test hinfnorm2(minreal(sysr_coprime_noscale - sysr_coprime_scale))[1] < 1e-5
+@test relative_freqresp_diff(sysr_coprime_noscale, sysr_coprime_scale) < 1e-8
 
 
 # baltrunc_unstab: compare frequency response with and without scaling
 sysr_unstab_noscale, _, _ = baltrunc_unstab(sys_siso; n=3)
 sysr_unstab_scale, _, _ = baltrunc_unstab(sys_siso; n=3, scaleY=scaleY, scaleU=scaleU)
 @test sysr_unstab_noscale.nx == sysr_unstab_scale.nx == 3
-@test hinfnorm2(minreal(sysr_unstab_noscale - sysr_unstab_scale))[1] < 1e-5
+@test relative_freqresp_diff(sysr_unstab_noscale, sysr_unstab_scale) < 1e-8


### PR DESCRIPTION
CI on master is red on a single assertion in `test/test_reduction.jl`:

```
Expression: norm(sysi * (sys - sysr), Inf) < 0.4
 Evaluated: 0.45825876482743627 < 0.4
```

## The bad bound

This is not a regression in this package — JuliaControl/RobustAndOptimalControl.jl#153 only touched `Project.toml`. It is a dependency bump: the last passing run resolved `ControlSystemsBase v1.20.4`, the failing one resolved `v1.21.0`, which reworked `_infnorm_two_steps_ct`, the kernel behind `hinfnorm` / `norm(·, Inf)`.

The test system is hardcoded, so the failure is fully deterministic. Pinning ControlSystemsBase back to 1.20.4 in an otherwise identical environment restores the old value:

| ControlSystemsBase | `norm(G, Inf)` | reported ω |
|---|---|---|
| 1.20.4 | 0.31417 | `Inf` |
| 1.21.0 | 0.45826 | 139.44 |

The brute-force peak gain of `G = sysi*(sys - sysr)` over a 200k-point grid from 1e-4 to 1e4 rad/s is **0.458258**, and `hinfnorm2` (via DescriptorSystems, unchanged across the bump) gives 0.458196 on both versions. So 1.21.0 is right and the old value was a bad under-estimate: `G` has a state dimension of 23 with near-cancelled poles from `fudge_inv` sitting close to the imaginary axis, and on that system the old algorithm got stuck at the lower bound `opnorm(D)` — hence the reported ω = Inf.

The bound of 0.4 was therefore calibrated against a wrong number rather than against the true norm, and is raised to 0.5. The reduction itself is unchanged across the bump: `norm(sys-sysr, Inf)`, the DC-gain residual property and the comparison against `baltrunc` all give identical values on both versions.

## The flaky scaling-invariance tests

Separately, the three scaling-invariance tests compared `hinfnorm2(minreal(sys1 - sys2))[1]` against an absolute tolerance. `sys_siso = ssrand(1,1,9,proper=true)` is unseeded, and for roughly 5% of draws `minreal` leaves a near-cancelled pole close enough to the imaginary axis that `ghinfnorm` returns `Inf` and the test fails (2/50 and 2/30 in two measurement loops). This is unrelated to the ControlSystemsBase change — it happened to pass in the failing run — but it would have bitten eventually.

They now compare the frequency responses on a grid, which is what the section comments already claimed they did. Worst relative difference over 200 random draws:

| check | worst over 200 draws |
|---|---|
| `baltrunc2` | 5.0e-13 |
| `baltrunc_coprime` | 1.4e-11 |
| `baltrunc_unstab` | 5.0e-13 |

so the `1e-8` relative tolerance keeps a wide margin while being three orders of magnitude tighter than the old absolute `1e-5`. `sys_siso` is left unseeded so the tests keep sampling new systems.

## Verification

- A daemon session that deterministically reproduces the unlucky draw returning `Inf` now passes it, 3/3 runs.
- `test_reduction.jl` in 4 fresh processes: 45 passed, 4 broken, exit 0.
- Full suite against ControlSystemsBase 1.21.0: **1414 passed, 6 broken, 0 failed** (the failing CI run had 1413 passed + 1 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
